### PR TITLE
fix filename extension

### DIFF
--- a/index.js
+++ b/index.js
@@ -82,8 +82,8 @@ function getDownloadUrl(version, platform) {
 function getDownloadFilename(version, platform) {
   const fileNamePlatformMatrix = {
     win32: 'windows-amd64.exe',
-    darwin: 'darwin-amd64',
-    linux: 'linux-amd64'
+    darwin: 'darwin-amd64.tar.gz',
+    linux: 'linux-amd64.tar.gz'
   }
   return `terraform-docs-${version}-${fileNamePlatformMatrix[platform]}`
 }


### PR DESCRIPTION
Fix filename extension in case of `linux-amd64` or `darwin-amd64 `otherwise:
```
[pre-commit/pre-commit] ⭐  Run Render terraform docs inside the USAGE.md
INFO[0034]   ☁  git clone 'https://github.com/lablabs/setup-terraform-docs' # ref=v1
[pre-commit/pre-commit]   🐳  docker cp src=/Users/vito.caldaralo/.cache/act/lablabs-setup-terraform-docs@v1/ dst=/var/run/act/actions/lablabs-setup-terraform-docs@v1/
[pre-commit/pre-commit]   🐳  docker exec cmd=[mkdir -p /var/run/act/actions/lablabs-setup-terraform-docs@v1/] user=
[pre-commit/pre-commit]   🐳  docker exec cmd=[node /var/run/act/actions/lablabs-setup-terraform-docs@v1/dist/index.js] user=
[pre-commit/pre-commit]   💬  ::debug::Requesting for [latest] version ...
[pre-commit/pre-commit]   💬  ::debug::... version resolved to [v0.16.0
[pre-commit/pre-commit]   💬  ::debug::Downloading Terraform docs version [v0.16.0] for platform [linux] from [https://github.com/terraform-docs/terraform-docs/releases/download/v0.16.0/terraform-docs-v0.16.0-linux-amd64] to destination [/root/terraform_docs/bin/terraform-docs]
[pre-commit/pre-commit]   💬  ::debug::Downloading https://github.com/terraform-docs/terraform-docs/releases/download/v0.16.0/terraform-docs-v0.16.0-linux-amd64
[pre-commit/pre-commit]   💬  ::debug::Destination /root/terraform_docs/bin/terraform-docs
[pre-commit/pre-commit]   💬  ::debug::Failed to download from "https://github.com/terraform-docs/terraform-docs/releases/download/v0.16.0/terraform-docs-v0.16.0-linux-amd64". Code(404) Message(Not Found)
[pre-commit/pre-commit]   ❗  ::error::Unexpected HTTP response: 404
[pre-commit/pre-commit]   ❌  Failure - Render terraform docs inside the USAGE.md
```